### PR TITLE
fixing return types

### DIFF
--- a/settingService/blockUser.go
+++ b/settingService/blockUser.go
@@ -19,7 +19,7 @@ type BlockUserRequestBody struct {
 // UnmarshalBlockUserRequestBody function unmarshals request for blocking of users into BlockUserRequestBody struct,
 // checks and retrieves value of is_blocked variable.
 // Function returns: if succeed - *BlockUserRequestBody, is_blocked value, nil,
-// if failed - nil, nil, err
+// if failed - nil, -1, err
 func UnmarshalBlockUserRequestBody(request *messageService.Message) (*BlockUserRequestBody, int, error) {
 	var body *BlockUserRequestBody
 	err := json.Unmarshal(request.Body, &body)
@@ -77,7 +77,8 @@ type ContactResult struct {
 }
 
 // IsUserBlocked checks if user is blocked for chatting in contacts table
-// Function returns: if succeed - true or false from contacts table(depend is contact blocked or not) and nil, if failed - nil and error
+// Function returns: if succeed - true or false from contacts table(depend is contact blocked or not) and nil,
+// if failed - true and error
 func IsUserBlocked(request *messageService.Message) (isBlocked bool, err error) {
 	isBlocked = true
 	var body messageService.MessageBody

--- a/settingService/blockUser.go
+++ b/settingService/blockUser.go
@@ -25,13 +25,13 @@ func UnmarshalBlockUserRequestBody(request *messageService.Message) (*BlockUserR
 	err := json.Unmarshal(request.Body, &body)
 	if err != nil {
 		loger.Log.Errorf("Error has occurred: ", err)
-		return nil, nil, err
+		return nil, -1, err
 	}
 	IsBlocked := body.IsBlocked // IsBlocked value could be int 0 or 1
 	if IsBlocked != 0 && IsBlocked != 1 {
 		err := errors.New("IsBlocked value is not valid. IsBlocked = " + string(IsBlocked))
 		loger.Log.Errorf("IsBlocked value is not 1 or 0:", err)
-		return nil, nil, err
+		return nil, -1, err
 	}
 	return body, IsBlocked, nil
 }
@@ -84,14 +84,14 @@ func IsUserBlocked(request *messageService.Message) (isBlocked bool, err error) 
 	err = json.Unmarshal(request.Body, &body)
 	if err != nil {
 		loger.Log.Errorf("Error has occurred: ", err)
-		return nil, err
+		return true, err
 	}
 	mainUser := body.ReceiverName
 	contactUser := request.Header.UserName
 	db, err := database.GetStorage() // common gorm-connection from database package
 	if err != nil {
 		loger.Log.Errorf("DB error has occurred: ", err)
-		return
+		return true, err
 	}
 	var result ContactResult //variable for storing result of querying into ContactResult struct
 	// SELECT main_user, contact_user, is_blocked FROM contacts

--- a/settingService/changeAboutUser.go
+++ b/settingService/changeAboutUser.go
@@ -22,18 +22,18 @@ func UnmarshalAboutUserRequestBody(request *messageService.Message) (string, err
 	err := json.Unmarshal(request.Body, &body)
 	if err != nil {
 		loger.Log.Errorf("Error has occurred: ", err)
-		return nil, err
+		return "", err
 	}
 	aboutUser := body.AboutUser
 	if aboutUser == "" {
 		err := errors.New("Info hasn't been filled")
 		loger.Log.Errorf("Error has occurred: ", err)
-		return nil, err
+		return "", err
 	}
 	if len(aboutUser) >= 999{ // column about_user in table users has length restriction - VARCHAR(1000)
 		err := errors.New("Too many symbols have been filled")
 		loger.Log.Errorf("Error has occurred: ", err)
-		return nil, err
+		return "", err
 	}
 	return aboutUser, nil
 }

--- a/settingService/changeAboutUser.go
+++ b/settingService/changeAboutUser.go
@@ -16,7 +16,7 @@ type ChangeAboutUserRequestBody struct {
 // UnmarshalAboutUserRequestBody function unmarshals request for changing field about_user(in table users)
 // into ChangeBirthdayRequestBody struct and retrieves value of to be stored in about_user field.
 // Function returns: if succeed - about_user value to be stored in users table, nil,
-// if failed - nil, err
+// if failed - "", err
 func UnmarshalAboutUserRequestBody(request *messageService.Message) (string, error) {
 	var body *ChangeAboutUserRequestBody
 	err := json.Unmarshal(request.Body, &body)

--- a/settingService/changeBirthday.go
+++ b/settingService/changeBirthday.go
@@ -22,7 +22,7 @@ func UnmarshalChangeBirthdayRequestBody(request *messageService.Message) (int, e
 	err := json.Unmarshal(request.Body, &body)
 	if err != nil {
 		loger.Log.Errorf("Error has occurred: ", err)
-		return nil, err
+		return -1, err
 	}
 	birthday := body.Birthday
 	return birthday, nil

--- a/settingService/changeBirthday.go
+++ b/settingService/changeBirthday.go
@@ -16,7 +16,7 @@ type ChangeBirthdayRequestBody struct {
 // UnmarshalBirthdayRequest function unmarshals request for changing birthday into ChangeBirthdayRequestBody struct
 // and retrieves value of birthday.
 // Function returns: if succeed - birthday value to be stored in users table, nil,
-// if failed - nil, err
+// if failed - -1, err
 func UnmarshalChangeBirthdayRequestBody(request *messageService.Message) (int, error) {
 	var body *ChangeBirthdayRequestBody
 	err := json.Unmarshal(request.Body, &body)


### PR DESCRIPTION
I've made mistakes with return types for int, string and bool values. Except -1, "" (empty string) and true I wrote nil, which is not correct!!!

From GO spec :  
// nil is a predeclared identifier representing the zero value for a
// pointer, channel, func, interface, map, or slice type.

In this PR return types have been fixed.